### PR TITLE
fix(): Ensure InfraDeploy dependsOn BuildApp OR runs independently

### DIFF
--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -61,7 +61,7 @@ parameters:
     default:
       - stage: NonProd
         dependsOn: Build
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+        condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
         environment_shortname: nonprod
         domain_internal: $(base_domain_internal_nonprod)
         build_app: BuildAppNonProd
@@ -69,7 +69,7 @@ parameters:
         deployment_apps: K8sNonProd
       - stage: Prod
         dependsOn: Build
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
         environment_shortname: prod
         domain_internal: $(base_domain_internal_prod)
         build_app: BuildAppProd
@@ -140,7 +140,17 @@ stages:
           # Pull in the non-production credentials for the build to use
           - group: sp-creds
         jobs:
+
+          - job: set_dependencies
+            displayName: 'Set Dependencies for Deployment'
+            pool: server
+            steps:
+              - ${{ if eq(parameters.run_build_app, 'true') }}:
+                  - script: echo "Running build_app"
+                    name: build_app_step
+
           - deployment: ${{ stage.build_app }}
+            dependsOn: set_dependencies
             condition: and(succeeded(), eq('${{ parameters.run_app_build }}', true))
             environment: ${{ variables.domain }}-${{ stage.environment_shortname }}
             pool:
@@ -188,7 +198,12 @@ stages:
                         tag: $(image_tag)
 
           - deployment: ${{ stage.deployment_infra }}
-            condition: and(succeeded(), eq('${{ parameters.deploy }}', true))
+            dependsOn:
+            - ${{ if eq(parameters.run_build_app, 'false') }}:
+              - set_dependencies
+            - ${{ else }}:
+              - ${{ stage.build_app }}
+            condition: or(eq( ${{ parameters.deploy }}, true), eq( ${{ parameters.destroy }}, true))
             environment: ${{ variables.domain }}-${{ stage.environment_shortname }}
             pool:
               vmImage: $(pool_vm_image)
@@ -286,21 +301,23 @@ stages:
                             testRunTitle: Terraform Redis Tests
                             failTaskOnFailedTests: true
 
-                    - task: Bash@3
-                      displayName: Deploy K8s Manifest YAML /w Application Image
-                      inputs:
-                        targetType: inline
-                        script: |
-                          taskctl infra:init
-                          taskctl app:deploy
-                      env:
-                        TF_FILE_LOCATION: /app/deploy/azure/terraform
-                        TF_VAR_name_environment: ${{ stage.environment_shortname }}
-                        TF_BACKEND_INIT: "key=$(tf_state_key),container_name=$(tf_state_container),storage_account_name=$(tf_state_storage),resource_group_name=$(tf_state_rg)"
-                        provider: $(provider) # could be CLOUD_PLATFORM
-                        target: $(aks_cluster)
-                        identifier: $(aks_resource_group)
-                        add_redis_key: $(create_redis)
+                    # Perform Manifest Deploy
+                    - ${{ if eq(parameters.deploy, true) }}:
+                      - task: Bash@3
+                        displayName: Deploy K8s Manifest YAML /w Application Image
+                        inputs:
+                          targetType: inline
+                          script: |
+                            taskctl infra:init
+                            taskctl app:deploy
+                        env:
+                          TF_FILE_LOCATION: /app/deploy/azure/terraform
+                          TF_VAR_name_environment: ${{ stage.environment_shortname }}
+                          TF_BACKEND_INIT: "key=$(tf_state_key),container_name=$(tf_state_container),storage_account_name=$(tf_state_storage),resource_group_name=$(tf_state_rg)"
+                          provider: $(provider) # could be CLOUD_PLATFORM
+                          target: $(aks_cluster)
+                          identifier: $(aks_resource_group)
+                          add_redis_key: $(create_redis)
 
   - stage: Release
     dependsOn:

--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -16,7 +16,7 @@ pr:
 trigger:
   branches:
     include:
-      - "master"
+      - "main"
   paths:
     include:
       - "*"
@@ -138,7 +138,7 @@ stages:
         condition: and(succeeded(), or(${{ stage.condition }}, ${{ parameters.force_deploy }}))
         variables:
           # Pull in the non-production credentials for the build to use
-          - group: sp-creds
+          - group: azure-sp-creds
         jobs:
 
           - job: set_dependencies
@@ -318,6 +318,7 @@ stages:
                           target: $(aks_cluster)
                           identifier: $(aks_resource_group)
                           add_redis_key: $(create_redis)
+                          namespace: $(namespace)
 
   - stage: Release
     dependsOn:
@@ -328,7 +329,7 @@ stages:
     condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(${{ parameters.pre_release }}, true)))
     variables:
       # TODO: Credentials should come from another group. `amido-stacks-github-credentials` are the old creds
-      - group: github-creds
+      - group: release-github-credentials
       - name: version_number
         value: "$(version_major).$(version_minor).$(version_revision)"
     jobs:

--- a/build/azDevOps/azure/deploy-infrastructure.yml
+++ b/build/azDevOps/azure/deploy-infrastructure.yml
@@ -16,7 +16,7 @@ pr:
 trigger:
   branches:
     include:
-      - "main"
+      - "master"
   paths:
     include:
       - "*"
@@ -61,7 +61,7 @@ parameters:
     default:
       - stage: NonProd
         dependsOn: Build
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
         environment_shortname: nonprod
         domain_internal: $(base_domain_internal_nonprod)
         build_app: BuildAppNonProd
@@ -69,7 +69,7 @@ parameters:
         deployment_apps: K8sNonProd
       - stage: Prod
         dependsOn: Build
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
         environment_shortname: prod
         domain_internal: $(base_domain_internal_prod)
         build_app: BuildAppProd

--- a/build/azDevOps/azure/pipeline-vars.yml
+++ b/build/azDevOps/azure/pipeline-vars.yml
@@ -85,6 +85,8 @@ variables:
     value:
   - name: aks_resource_group
     value:
+  - name: namespace
+    value:
 
   # ------- GitHub
   - name: create_release

--- a/build/common/scripts/Deploy-Namespace.ps1
+++ b/build/common/scripts/Deploy-Namespace.ps1
@@ -1,0 +1,50 @@
+[CmdletBinding()]
+param (
+  [string]
+  $target = $env:target, # AKS Cluster
+
+  [string]
+  $identifier = $env:identifier, # AKS Resource Group
+
+  [string]
+  $provider = $env:provider, # Cloud Provider (Azure)
+
+  [string]
+  $namespace = $env:namespace, # Namespace of your app in AKS Namespaces
+
+  [switch]
+  $VerboseOutput
+)
+
+# Set the Verbose Output Switch if you want to get log outputs when running TaskCTL
+if ($VerboseOutput) {
+  $VerbosePreference = 'Continue'
+  Write-Verbose "Verbose mode enabled"
+}
+
+# Validate that all required parameters are populated
+$requiredParams = @{
+  namespace  = $namespace
+  target     = $target
+  identifier = $identifier
+  provider   = $provider
+}
+
+foreach ($param in $requiredParams.GetEnumerator()) {
+  if (-not $param.Value) {
+    Write-Error "The parameter '$($param.Key)' is required."
+    exit 1
+  }
+}
+
+Write-Verbose "Checking if namespace $namespace exists."
+$namespaceExists = Invoke-Kubectl -custom -arguments @("get namespace $namespace --ignore-not-found") -provider $env:provider -target $env:target -identifier $env:identifier
+Write-Verbose "$namespaceExists"
+
+if ($namespaceExists -match "nx\s+Active") {
+  Write-Verbose "$namespace exists! No need to create it."
+}
+else {
+  Write-Verbose "$namespace does not exist, creating it now."
+  Invoke-Kubectl -custom -arguments @("create namespace $namespace") -provider $env:provider -target $env:target -identifier $env:identifier
+}

--- a/build/common/scripts/Deploy-Secret.ps1
+++ b/build/common/scripts/Deploy-Secret.ps1
@@ -24,9 +24,47 @@ param (
   [string]
   $secretName = "nx-secret",
 
+  [hashtable]
+  $secretHash = @{"redis_connection_string" = $null },
+
+  [string]
+  $outputFile = "secrets.yaml",
+
+  [string]
+  $namespace = $env:namespace,
+
   [switch]
   $VerboseOutput
 )
+
+function Update-KubernetesSecret {
+  param (
+    [string]$Namespace,
+    [string]$SecretName,
+    [hashtable]$Data,
+    [string]$OutputFile
+  )
+
+  # Create the secret YAML content
+  $secretYaml = @"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $SecretName
+  namespace: $Namespace
+type: Opaque
+data:
+"@
+
+  foreach ($key in $Data.Keys) {
+    # Add the base64 encoded value to the YAML content
+    $secretYaml += "`n  $($key): $($Data[$key])`n"
+  }
+
+  # Save the YAML content to the output file
+  Set-Content -Path $OutputFile -Value $secretYaml
+  return
+}
 
 # Set the Verbose Output Switch if you want to get log outputs when running TaskCTL
 if ($VerboseOutput) {
@@ -36,12 +74,10 @@ if ($VerboseOutput) {
 
 # Validate that all required parameters are populated
 $requiredParams = @{
+  namespace                = $namespace
   redis_hostname           = $redis_hostname
   redis_port               = $redis_port
   redis_primary_access_key = $redis_primary_access_key
-  target                   = $target
-  identifier               = $identifier
-  provider                 = $provider
 }
 
 foreach ($param in $requiredParams.GetEnumerator()) {
@@ -58,22 +94,24 @@ if ($env:add_redis_key -eq "true") {
   # they will be decoded when fetched by the application.
   Write-Verbose "Generating K8s Secret"
   $redis_connection_string = "$($redis_hostname):$($redis_port),password=$($redis_primary_access_key),ssl=True,abortConnect=False"
-  $base64EncodedString = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($redis_connection_string))
+  $bytes = [System.Text.Encoding]::UTF8.GetBytes($redis_connection_string)
+  $base64EncodedString = [System.Convert]::ToBase64String($bytes)
+  $secretHash.redis_connection_string = $base64EncodedString
 
   # Ensure that the secret isn't present, and add. If it is, skip this step entirely.
   Write-Verbose "Logging Into K8s & Seeing If Secret Exists"
-  $secretExists = Invoke-Kubectl -custom -arguments @("get secret $secretName --ignore-not-found") -provider $env:provider -target $env:target -identifier $env:identifier
+  $secretExists = Invoke-Kubectl -custom -arguments @("get secret $secretName --ignore-not-found --namespace=$namespace") -provider $env:provider -target $env:target -identifier $env:identifier
+  Write-Verbose "$secretExists"
 
-  if ($secretExists) {
-    Write-Verbose "Secret '$secretName' already exists. No need to create a new one."
-  }
-  else {
-    Write-Verbose "Secret '$secretName' does not exist. Creating a new secret."
-    # Create the Kubernetes secret
-    Invoke-Kubectl -custom -arguments @("create secret generic nx-secret --from-literal=redis_connection_string='$base64EncodedString'") -provider $env:provider -target $env:target -identifier $env:identifier
-    Write-Verbose "Completed K8s Secret creation"
+  # Determine if secret needs to be deleted before re-applying
+  if ($secretExists -match "nx-secret\s+Opaque") {
+    Invoke-Kubectl -custom -arguments @("delete secret $SecretName -n $Namespace") -provider $env:provider -target $env:target -identifier $env:identifier
   }
 
-  Write-Verbose "Completed K8s Secret Apply"
+  # Apply dynamically created secret manifest
+  Update-KubernetesSecret -Namespace $namespace -SecretName $secretName -Data $secretHash -OutputFile $outputFile
+  Invoke-Kubectl -apply -arguments @($outputFile) -provider $env:provider -target $env:target -identifier $env:identifier
+  Exit 0
 }
 
+Write-Verbose "Redis Secret isn't required, no K8s secret will be applied."

--- a/build/common/taskctl/tasks.yaml
+++ b/build/common/taskctl/tasks.yaml
@@ -125,6 +125,7 @@ tasks:
       - |
         Import-Module Az.Aks # This is loaded here as when it is imported in lower down modules you end up with conflicts with assembly tasks within Azure DevOps Backend!
         ./build/common/scripts/Prepare-TerraformOutputs.ps1 -VerboseOutput
+        ./build/common/scripts/Deploy-Namespace.ps1 -VerboseOutput
         ./build/common/scripts/Deploy-Secret.ps1 -VerboseOutput
         ./build/common/scripts/Deploy-Manifests.ps1 -VerboseOutput
 

--- a/deploy/common/app/k8s-manifest/deployment.yaml
+++ b/deploy/common/app/k8s-manifest/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nx-app
+  namespace: nx
   labels:
     app: nx-app
 spec:
@@ -16,11 +17,11 @@ spec:
     spec:
       containers:
       - name: nx-container
-        image: redistestreg.azurecr.io/nx-app:test # Replace with the NX App Image
+        image: ensonoeuw.azurecr.io/nx:latest # Replace with the NX App Image
         ports:
         - containerPort: 3000
         envFrom:
-        - configMapRef:
-            name: nx-config
+        # - configMapRef:
+        #     name: nx-config
         - secretRef:
             name: nx-secret

--- a/deploy/common/app/k8s-manifest/ingress.yaml
+++ b/deploy/common/app/k8s-manifest/ingress.yaml
@@ -2,11 +2,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nx-app-ingress
+  namespace: nx
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
+  ingressClassName: nginx
   rules:
-  - host: my.local  # Replace with your domain or use a local host
+  - host: nx.nonprod.stacks.ensono.com  # Replace with your domain or use a local host
     http:
       paths:
       - path: /
@@ -16,4 +18,6 @@ spec:
             name: nx-app-service
             port:
               number: 80
-
+  tls:
+    - hosts:
+        - nonprod.stacks.ensono.com

--- a/deploy/common/app/k8s-manifest/service.yaml
+++ b/deploy/common/app/k8s-manifest/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nx-app-service
+  namespace: nx
   labels:
     app: nx-app
 spec:


### PR DESCRIPTION
### What
Ensure that InfraDeploy/Destroy is able to run independently when BuildApp isn't selected in the pipeline run

### How
Add a dummy job to the second stage of the pipeline, allowing InfraDeploy to validate based on parameters and derrive its dependsOn use case.

Alternative solution would be to template and have two callers in the parent template, OR have a dependsOn to the first stage, and a dependsOn to `stage1.job1` for example.